### PR TITLE
feat: add utils for `event.data.object` type lookups

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -803,3 +803,28 @@ declare module "stripe" {
     }
   }
 }
+
+/**
+ * A map of every Stripe webhook event to its respective `event.data.object` type.
+ */
+export type StripeEventDataObjectMap = {
+  [EventType in Stripe.DiscriminatedEvent.Type]: GetDataObjectTypeForEvent<EventType>;
+};
+
+/**
+ * Generic util which takes a Stripe event name and returns the event's `event.data.object` type.
+ *
+ * @example
+ * ```ts
+ * GetDataObjectTypeForEvent<"account.updated">; //                  Stripe.Account
+ * GetDataObjectTypeForEvent<"customer.subscription.updated">; //    Stripe.Subscription
+ * GetDataObjectTypeForEvent<"account.external_account.created">; // Stripe.Card | Stripe.BankAccount
+ * ```
+ */
+export type GetDataObjectTypeForEvent<EventName extends Stripe.DiscriminatedEvent.Type> = ValueOf<{
+  [Obj in Stripe.DiscriminatedEvent as { type: EventName } extends Pick<Obj, "type">
+    ? EventName
+    : never]: Obj extends { data: { object: object } } ? Obj["data"]["object"] : never;
+}>;
+
+type ValueOf<Obj> = Obj[keyof Obj];


### PR DESCRIPTION
This commit adds 2 util types:

1. `GetDataObjectTypeForEvent` takes a Stripe event-name type param (Stripe.DiscriminatedEvent.Type) and returns the event's corresponding `event.data.object` type. 
   > Example: `GetDataObjectTypeForEvent<"account.updated">; // Stripe.Account`
   
2. `StripeEventDataObjectMap` uses `GetDataObjectTypeForEvent` to map each `Stripe.DiscriminatedEvent.Type` to its corresponding `event.data.object` type.

These util types facilitate the creation of strongly-typed event handlers. While the package's existing types allow for a Stripe-webhooks event controller to have the correct type for `event.data.object` once narrowing has occurred via the `event.type` discriminant property, it lacks the ability for existing type-relationships already defined in the package to be used in other contexts. For example:
```ts
const myHandlerForAccountUpdatedEvents = (
  dataObj: GetDataObjectTypeForEvent<"account.updated">
) => { ... }
```